### PR TITLE
Add ECS scripts, fix k8s/helm doc

### DIFF
--- a/ecs.md
+++ b/ecs.md
@@ -1,0 +1,60 @@
+# Prodfiler on ECS
+
+To setup Prodfiler on ECS two scripts should be run on a Linux/Mac (respect the order):
+* `prodfiler-ecs-auth.sh`: configures credentials to pull the `optimyze/pf-host-agent` image
+and IAM resources to consume the secret
+* `prodfiler-ecs-task.sh`: deploys a `DAEMON` task in an already-existing ECS cluster
+
+## ECS support
+
+Currently Prodfiler is available only on ECS clusters with **EC2 launch type**.
+Fargate launch type does not allow deploying `DEAMON` tasks and thus is not an option at the moment.
+
+## IAM Permissions
+
+To run this script we suggest to use AWS credentials with the following policies attached:   
+
+* `arn:aws:iam::aws:policy/SecretsManagerReadWrite`
+* `arn:aws:iam::aws:policy/IAMFullAccess`
+* `arn:aws:iam::aws:policy/AmazonECS_FullAccess`
+
+## Deploying Prodfiler 
+
+Both scripts are _not_ idempotent so they should be executed from AWS credentials 
+with the proper authorizations to manage the impacted resources. If the script fails during the execution,
+the resources created so far will have to be deleted manually for the script to succeed on then next run.
+
+Scripts use AWS CLI v2, refer to [the official doc](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+to set it up. 
+
+To see the help message, call the scripts with `-h` or `--help`.
+
+### Authentication and secrets
+
+Use the provided credentials to access the private Docker image as arguments of this script.
+Run this command from the root of the `scripts/ecs/awscli` directory:
+
+```bash
+./prodfiler-ecs-auth.sh --username optimyzeprodfilerbeta --password 6e40c039-2639-4790-993d-1dd58ce74053
+```
+
+It will create the secrets used by the ECS DAEMON task using AWS Secret Manager.
+
+### ECS task
+
+Fetch the `projectID` and `secretToken` values visible in the Prodfiler web UI
+when creating a new project.
+The values are defined as environment variables in the deployment command visible in the UI,
+they are called `PRODFILER_PROJECT_ID` and `PRODFILER_SECRET_TOKEN` respectively.
+
+Run the script:
+
+```bash
+./prodfiler-ecs-task.sh --cluster-arn <YOUR_CLUSTER_ARN> \
+        --collection-agent "dev.prodfiler.com:10000" \
+        --project-id <YOUR_PROJECT_ID>
+        --version "release-beta-1"
+        --tracers "all"
+        --secret-token <YOUR_SECRET_TOKEN>
+```
+At this point Prodfiler Host Agent should be running in your ECS cluster and you should start seeing data in the UI.

--- a/getting-started.md
+++ b/getting-started.md
@@ -42,13 +42,15 @@ docker run --name prodfiler --privileged --pid=host -v /etc/machine-id:/etc/mach
    -e PRODFILER_PROJECT_ID=[YYYY] \
    -e PRODFILER_SECRET_TOKEN=[ZZZZ] \
    -e PRODFILER_COLLECTION_AGENT=dev.prodfiler.com:10000 \
-   optimyze/pf-host-agent:release-beta-1 /root/pf-host-agent -t all 
+   optimyze/pf-host-agent:release-beta-1 /root/pf-host-agent 
 ```
 
 Let's unpack this: The first line logs you into the `dockerhub` repository that contains the
 container `optimyze/pf-host-agent:release-beta-1`, and the second line starts this container
 with your project ID and a secret token (that you need to keep secret to ensure that others cannot
-pollute your project with data).
+pollute your project with data) configured as environment variables.
+The container needs to be `privileged` because Prodfiler interacts with the kernel features that are 
+typically only available to the `root` user; the volume mounts expose debugging information to the Prodfiler agent.
 
 ### Manual installation on a single host
 
@@ -62,7 +64,7 @@ Please refer to the instructions [here](./kubernetes.md).
 
 ### Deploying to a fleet of ECS nodes
 
-TBD
+Please refer to the instructions [here](./ecs.md).
 
 ### Deploying via Nomad
 

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -12,7 +12,8 @@ The agent is deployed as a DaemonSet and requires a `privileged` security contex
 
 * Add the Helm repository hosting the Optimyze charts, you only need to run this when first installing:
   ```bash
-  helm repo add optimyze-prodfiler s3://optimyze-prodfiler-deployment/charts/pf-host-agent
+  helm repo add optimyze https://optimyze.cloud/helm-charts
+  helm repo update
   ```
 
 * Fetch the `projectID` and `secretToken` values visible in the Prodfiler web UI
@@ -25,7 +26,7 @@ The agent is deployed as a DaemonSet and requires a `privileged` security contex
   ```bash
   helm install --namespace=prodfiler pf-host-agent \
   --set "projectID=<projectID>,secretToken=<secretToken>" \
-  optimyze-prodfiler/pf-host-agent
+  optimyze/pf-host-agent
   ```
 
 ## Customizing values
@@ -34,7 +35,7 @@ For more complex deployment you may want to customize Helm values.
 You can list the possible values using:
 
 ```bash
-helm show values optimyze-prodfiler/pf-host-agent
+helm show values optimyze/pf-host-agent
 ```
 
 The most notable configuration knobs are `nodeSelector` and `tolerations` to deploy Prodfiler Host Agent

--- a/nomad.md
+++ b/nomad.md
@@ -49,7 +49,7 @@ job "prodfiler-agent" {
         privileged = true
         auth {
           username = "optimyzeprodfilerbeta"
-          password = "betaprodfiler"
+          password = "6e40c039-2639-4790-993d-1dd58ce74053"
         }
         force_pull = true
         pid_mode = "host"

--- a/scripts/ecs/awscli/.gitignore
+++ b/scripts/ecs/awscli/.gitignore
@@ -1,0 +1,1 @@
+task*.json

--- a/scripts/ecs/awscli/prodfiler-ecs-auth.sh
+++ b/scripts/ecs/awscli/prodfiler-ecs-auth.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+function usage() {
+    echo "ECS Prodfiler Auth setup"
+    echo ""
+    echo "This script sets up IAM role for ECS Prodfiler DAEMON task: authentication to private registry and IAM role/policies to consume the secret."
+    echo "You will need several IAM and SecretsManager permissions for the script to complete successfully... see the README for more details."
+    echo "Dependencies: aws, jq"
+    echo ""
+    echo "Example usage (please note arg=value syntax is not supported):"
+    echo "$0 --username foo --password bar"
+}
+
+if [ "$#" -ne 4 ]; then usage; exit 1; fi
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        --username) username="$2"; shift ;;
+        --password) password="$2"; shift ;;
+        *) echo "unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# disables the less pager
+export AWS_PAGER=cat
+
+echo "creating a secret with credentials to pull images"
+secretString="{\"username\":\"$username\", \"password\":\"$password\"}"
+secretTags="[{\"Key\":\"Scope\",\"Value\":\"profiling\"},{\"Key\":\"Provider\",\"Value\":\"optimyze\"}]"
+aws secretsmanager create-secret --name optimyze/prodfiler/pullSecret --secret-string "$secretString" --tags "$secretTags"
+
+read -r -d '' assumeRolePolicy << EOM
+{
+  "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ecs-tasks.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+}
+EOM
+
+echo "creating an IAM role for ECS Prodfiler tasks"
+aws iam create-role --role-name ecsProdfilerTaskExecutionRole --path "/optimyze/prodfiler/" --assume-role-policy-document "$assumeRolePolicy" \
+ --description "Enables ECS Prodfiler DAEMON permissions"
+
+read -r -d '' pullPolicy << EOM
+{
+  "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "secretsmanager:GetSecretValue"
+        ],
+        "Resource": [
+          "arn:aws:secretsmanager:*:*:secret:optimyze/prodfiler/pullSecret*"
+        ]
+      }
+    ]
+}
+EOM
+
+echo "creating a policy to allow ECS task to consume the image pull secret"
+policyArn=$(aws iam create-policy --policy-name AmazonECSAllowPrivateRegistryPullSecrets \
+  --path "/optimyze/prodfiler/" --policy-document "$pullPolicy" | jq -r '.Policy.Arn')
+
+echo "attaching the proper policies the the IAM role"
+aws iam attach-role-policy --role-name ecsProdfilerTaskExecutionRole \
+  --policy-arn  arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+aws iam attach-role-policy --role-name ecsProdfilerTaskExecutionRole \
+  --policy-arn "$policyArn"
+
+echo "success!"

--- a/scripts/ecs/awscli/prodfiler-ecs-task.sh
+++ b/scripts/ecs/awscli/prodfiler-ecs-task.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function usage() {
+    echo "ECS Prodfiler Task setup"
+    echo ""
+    echo "This script sets up a DAEMON task for Prodfiler in an already existing cluster."
+    echo "You will need several ECS permissions for the script to complete successfully... see the README for more details."
+    echo "Dependencies: aws, jq, mktemp"
+    echo ""
+    echo "Example usage (please note arg=value syntax is not supported):"
+    echo "$0 --cluster-arn foo --collection-agent app.prodfiler.com:10000 --project-id 123 --secret-token aaabbbcccddd123 --version v1.2.3 --tracers (all|native) --secret-token foobar123"
+}
+
+if [ "$#" -ne 12 ]; then usage; exit 1; fi
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage; exit 0 ;;
+        --cluster-arn) clusterArn="$2"; shift ;;
+        --collection-agent) collectionAgentHostPort="$2"; shift ;;
+        --project-id) projectId="$2"; shift ;;
+        --version) version="$2"; shift ;;
+        --tracers) tracers="$2"; shift ;;
+        --secret-token) secretToken="$2"; shift ;;
+        *) echo "unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+export AWS_PAGER=cat
+
+echo "get the pullSecret ARN"
+pullSecretArn=$(aws secretsmanager list-secrets --filter "Key=name,Values=optimyze/prodfiler/pullSecret" | jq -r '.SecretList[0].ARN')
+
+echo "get the task execution role ARN"
+ecsRoleArn=$(aws iam get-role --role-name ecsProdfilerTaskExecutionRole | jq -r '.Role.Arn')
+
+echo "building temporary file to hold ECS task cli-input-json"
+tmpFile=$(mktemp -p $PWD -t task_XXX.json)
+awk '{ gsub("_pullSecretArn_",p); gsub("_ecsRoleArn_",e); gsub("_collectionAgentHostPort_",c); gsub("_projectId_",pr); gsub("_version_",v); gsub("_tracers_",t); gsub("_secretToken_",s);print }' \
+  p="$pullSecretArn" e="$ecsRoleArn" c="$collectionAgentHostPort" pr="$projectId" v="$version" t="$tracers" s="$secretToken"\
+  task.json.template > $tmpFile
+
+echo "registering a Prodfiler task inside cluster $clusterArn"
+aws ecs register-task-definition --cli-input-json file://$tmpFile
+
+echo "creating Prodfiler DAEMON service inside cluster $clusterArn"
+aws ecs create-service --cluster $clusterArn --service-name optimyze-prodfiler \
+  --task-definition optimyze-prodfiler --launch-type EC2 --scheduling-strategy DAEMON
+
+echo "success!"

--- a/scripts/ecs/awscli/task.json.template
+++ b/scripts/ecs/awscli/task.json.template
@@ -1,0 +1,74 @@
+{
+  "executionRoleArn": "_ecsRoleArn_",
+  "containerDefinitions": [
+    {
+      "entryPoint": [
+        "/root/pf-host-agent"
+      ],
+      "command": [
+        "-t=_tracers_",
+        "-collection-agent=_collectionAgentHostPort_",
+        "-project-id=_projectId_",
+        "-optimyze-homedir=/opt/optimyze",
+        "-config=/dev/null",
+        "-secret-token=_secretToken_"
+      ],
+      "linuxParameters": {
+        "capabilities": {
+          "add": [
+            "SYS_ADMIN"
+          ]
+        }
+      },
+      "cpu": 512,
+      "environment": [
+          {
+            "name": "GODEBUG",
+            "value": "madvdontneed=1"
+          }
+      ],
+      "repositoryCredentials": {
+        "credentialsParameter": "_pullSecretArn_"
+      },
+      "mountPoints": [
+        {
+          "readOnly": true,
+          "containerPath": "/sys/kernel/debug",
+          "sourceVolume": "kerneldebug"
+        },
+        {
+          "readOnly": true,
+          "containerPath": "/etc/machine-id",
+          "sourceVolume": "machineid"
+        }
+      ],
+      "memory": 512,
+      "memoryReservation": 400,
+      "image": "optimyze/pf-host-agent:_version_",
+      "essential": true,
+      "user": "root",
+      "name": "prodfiler"
+    }
+  ],
+  "memory": "512",
+  "family": "optimyze-prodfiler",
+  "pidMode": "host",
+  "requiresCompatibilities": [
+    "EC2"
+  ],
+  "cpu": "512",
+  "volumes": [
+    {
+      "name": "machineid",
+      "host": {
+        "sourcePath": "/etc/machine-id"
+      }
+    },
+    {
+      "name": "kerneldebug",
+      "host": {
+        "sourcePath": "/sys/kernel/debug"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Content
* add ECS scripts, referenced in the ECS docs
* fix k8s/helm for host-agent using the new setup on GitHub pages to host Helm charts 