### PR TITLE
ECS: amend task template to include privileged Docker flag

### DIFF
--- a/scripts/ecs/awscli/prodfiler-ecs-task.sh
+++ b/scripts/ecs/awscli/prodfiler-ecs-task.sh
@@ -38,7 +38,7 @@ echo "get the task execution role ARN"
 ecsRoleArn=$(aws iam get-role --role-name ecsProdfilerTaskExecutionRole | jq -r '.Role.Arn')
 
 echo "building temporary file to hold ECS task cli-input-json"
-tmpFile=$(mktemp -p $PWD -t task_XXX.json)
+tmpFile=$(mktemp -t task_XXX.json)
 awk '{ gsub("_pullSecretArn_",p); gsub("_ecsRoleArn_",e); gsub("_collectionAgentHostPort_",c); gsub("_projectId_",pr); gsub("_version_",v); gsub("_tracers_",t); gsub("_secretToken_",s);print }' \
   p="$pullSecretArn" e="$ecsRoleArn" c="$collectionAgentHostPort" pr="$projectId" v="$version" t="$tracers" s="$secretToken"\
   task.json.template > $tmpFile

--- a/scripts/ecs/awscli/task.json.template
+++ b/scripts/ecs/awscli/task.json.template
@@ -13,6 +13,7 @@
         "-config=/dev/null",
         "-secret-token=_secretToken_"
       ],
+      "privileged": true,
       "linuxParameters": {
         "capabilities": {
           "add": [


### PR DESCRIPTION
## Reason for this PR
ECS task can't be run as the host-metadata collection requires the task to run with the `privileged` Docker flag.

## Details
Add the flag
