### PR TITLE
more explicit reference to minimum supported kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ from the SPARK AI Summit.
 Both Google and Facebook achieve this capability by recompiling all dependencies from scratch and
 generally do not make this capability available to the outside world.
 
-Prodfiler is designed to bring the same capability to **everybody** (provided that they are running
-at least a 4.15 Linux Kernel).
+Prodfiler is designed to bring the same capability to **everybody** running a Linux Kernel with version 4.15 or higher.
 
 ## Why use Prodfiler?
 
@@ -71,6 +70,8 @@ We have a detailed [FAQ](faq.md) which can answer many of the frequently-asked q
 If you encounter any problem, check our [troubleshooting](troubleshooting.md) page. If that does
 not help, please open an issue and/or contact prodfiler-support@optimyze.cloud
 
+## Supported platforms and dependencies
 
-
-
+* Linux
+  
+        kernel >= 4.15

--- a/ecs.md
+++ b/ecs.md
@@ -5,6 +5,11 @@ To setup Prodfiler on ECS two scripts should be run on a Linux/Mac (respect the 
 and IAM resources to consume the secret
 * `prodfiler-ecs-task.sh`: deploys a `DAEMON` task in an already-existing ECS cluster
 
+Before installing Prodfiler, verify that your nodes meet the [support requirements](README.md#supported-platforms).
+So far, the default Linux AMI 2 ships with an unsupported Linux kernel version (4.14); check the
+[Amazon Linux 2 AMI release notes](https://aws.amazon.com/amazon-linux-2/release-notes/) to verify 
+support for the current kernel version.  
+
 ## ECS support
 
 Currently Prodfiler is available only on ECS clusters with **EC2 launch type**.

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -2,6 +2,8 @@
 
 The agent is deployed as a DaemonSet and requires a `privileged` security context as it needs access to the nodes' kernel features.
 
+Before installing Prodfiler, verify that your nodes meet the [support requirements](README.md#supported-platforms).
+
 ## Quick start installation
 
 * Create a namespace to host Prodfiler (and optionally label it), here we use `prodfiler`:

--- a/nomad.md
+++ b/nomad.md
@@ -1,5 +1,7 @@
 # Deploying via Nomad
 
+Before installing Prodfiler, verify that your nodes meet the [support requirements](README.md#supported-platforms).
+
 Below an example Nomad config to deploy the agent on 20% of machines, up to 100 deployments:
 
 ```


### PR DESCRIPTION
## Reason for this PR
We need to make more explicit the support of a minimum kernel version when installing in customers' clusters (Nomad, Kubernetes, ECS)

## Details
Update docs with a more explicit reference
